### PR TITLE
Fix PyPDF2 capitalization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core PDF processing libraries
 pytest
 pymupdf
-pyPDF2
+PyPDF2
 
 # Chromadb and vector databases
 chromadb


### PR DESCRIPTION
## Summary
- fix the capitalization for PyPDF2 in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68514d73e2288329a5a420172772465c